### PR TITLE
Use env for backend URL

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -3,7 +3,7 @@ module.exports = {
   env: { browser: true, es2020: true },
   extends: [
     'eslint:recommended',
-    '@typescript-eslint/recommended',
+    'plugin:@typescript-eslint/recommended',
     'plugin:react-hooks/recommended',
   ],
   ignorePatterns: ['dist', '.eslintrc.cjs'],

--- a/SETUP.md
+++ b/SETUP.md
@@ -30,7 +30,7 @@ VITE_GOOGLE_CALENDAR_ID=your_calendar_id_here
    - Go to "APIs & Services" > "Credentials"
    - Click "Create Credentials" > "OAuth 2.0 Client IDs"
    - Choose "Web application"
-   - Add authorized redirect URI: `http://localhost:3001/auth/google/callback`
+   - Add authorized redirect URI: `http://<YOUR_BACKEND_URL>:3001/auth/google/callback`
    - Copy the Client ID and Client Secret to your `.env` file
 
 ### 3. Running the Application

--- a/authenticate.sh
+++ b/authenticate.sh
@@ -4,7 +4,8 @@ echo "🔐 Starting Google OAuth2 Authentication..."
 echo ""
 
 # Get the auth URL
-AUTH_RESPONSE=$(curl -s http://localhost:3001/auth/google)
+BACKEND_URL="${VITE_BACKEND_URL:-http://localhost:3001}"
+AUTH_RESPONSE=$(curl -s "$BACKEND_URL/auth/google")
 AUTH_URL=$(echo $AUTH_RESPONSE | grep -o '"authUrl":"[^"]*"' | cut -d'"' -f4)
 
 if [ -z "$AUTH_URL" ]; then
@@ -30,7 +31,7 @@ if [ -z "$AUTH_CODE" ]; then
 fi
 
 echo "🔄 Exchanging code for tokens..."
-TOKEN_RESPONSE=$(curl -s "http://localhost:3001/auth/google/callback?code=$AUTH_CODE")
+TOKEN_RESPONSE=$(curl -s "$BACKEND_URL/auth/google/callback?code=$AUTH_CODE")
 
 if echo "$TOKEN_RESPONSE" | grep -q '"success":true'; then
     echo "✅ Authentication successful!"

--- a/env.example
+++ b/env.example
@@ -12,4 +12,5 @@ WHISPER_MODEL_PATH=./whisper.cpp/models/ggml-base.en.bin
 
 # App Configuration
 VITE_APP_NAME=Home Hub
-VITE_APP_VERSION=1.0.0 
+VITE_APP_VERSION=1.0.0
+VITE_BACKEND_URL=http://localhost:3001

--- a/fix-home-hub.sh
+++ b/fix-home-hub.sh
@@ -27,8 +27,9 @@ echo "4. Waiting for backend to start..."
 sleep 5
 
 # Check if backend is running
-if curl -s http://localhost:3001/api/health > /dev/null; then
-    echo "✅ Backend is running on http://localhost:3001"
+BACKEND_URL="${VITE_BACKEND_URL:-http://localhost:3001}"
+if curl -s "$BACKEND_URL/api/health" > /dev/null; then
+    echo "✅ Backend is running on $BACKEND_URL"
 else
     echo "❌ Backend failed to start"
     exit 1
@@ -48,8 +49,8 @@ echo "================================"
 echo "🎉 Home Hub is now running!"
 echo ""
 echo "📱 Frontend: http://$IP_ADDRESS:5173/"
-echo "🔧 Backend:  http://localhost:3001/api/health"
-echo "🔐 OAuth:    http://localhost:3001/auth/google"
+echo "🔧 Backend:  $BACKEND_URL/api/health"
+echo "🔐 OAuth:    $BACKEND_URL/auth/google"
 echo ""
 echo "💡 To access from Windows, use: http://$IP_ADDRESS:5173/"
 echo "💡 To stop servers: pkill -f 'node.*server' && pkill -f 'vite'"

--- a/server/index.js
+++ b/server/index.js
@@ -31,7 +31,8 @@ app.use(express.json())
 // Google OAuth2 configuration
 const CLIENT_ID = process.env.VITE_GOOGLE_CLIENT_ID
 const CLIENT_SECRET = process.env.VITE_GOOGLE_CLIENT_SECRET
-const REDIRECT_URI = 'http://localhost:3001/auth/google/callback'
+const BACKEND_URL = process.env.VITE_BACKEND_URL || 'http://localhost:3001'
+const REDIRECT_URI = `${BACKEND_URL}/auth/google/callback`
 const CALENDAR_ID = process.env.VITE_GOOGLE_CALENDAR_ID || 'primary'
 
 // Create OAuth2 client

--- a/src/components/AuthTest.tsx
+++ b/src/components/AuthTest.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { Shield, CheckCircle, XCircle, Loader, ExternalLink } from 'lucide-react'
+import { backendUrl } from '../utils/backend'
 
 const AuthTest: React.FC = () => {
   const [authStatus, setAuthStatus] = useState<string | null>(null)
@@ -15,7 +16,7 @@ const AuthTest: React.FC = () => {
       console.log('🔐 Testing OAuth2 authentication...')
       
       // Test 1: Check if backend is configured
-      const healthResponse = await fetch('http://localhost:3001/api/health')
+      const healthResponse = await fetch(backendUrl('/api/health'))
       const healthData = await healthResponse.json()
       
       if (!healthData.oauthConfigured) {
@@ -26,7 +27,7 @@ const AuthTest: React.FC = () => {
       console.log('✅ Backend is configured')
 
       // Test 2: Try to test calendar API (will fail if not authenticated)
-      const testResponse = await fetch('http://localhost:3001/api/calendar/test')
+      const testResponse = await fetch(backendUrl('/api/calendar/test'))
       const testData = await testResponse.json()
 
       if (testResponse.status === 401) {
@@ -59,7 +60,7 @@ const AuthTest: React.FC = () => {
     try {
       console.log('🔐 Starting OAuth2 flow...')
       
-      const authResponse = await fetch('http://localhost:3001/auth/google')
+      const authResponse = await fetch(backendUrl('/auth/google'))
       const authData = await authResponse.json()
       
       if (authData.authUrl) {
@@ -85,7 +86,7 @@ const AuthTest: React.FC = () => {
     try {
       console.log('🔍 Checking authentication status...')
       
-      const testResponse = await fetch('http://localhost:3001/api/calendar/test')
+      const testResponse = await fetch(backendUrl('/api/calendar/test'))
       const testData = await testResponse.json()
 
       if (testResponse.ok) {

--- a/src/components/DebugPanel.tsx
+++ b/src/components/DebugPanel.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { Bug, RefreshCw, CheckCircle, XCircle, Shield } from 'lucide-react'
+import { backendUrl } from '../utils/backend'
 
 const DebugPanel: React.FC = () => {
   const [testResult, setTestResult] = useState<string | null>(null)
@@ -13,7 +14,7 @@ const DebugPanel: React.FC = () => {
       console.log('🧪 Starting debug test...')
       
       // Test 1: Check backend health
-      const healthResponse = await fetch('http://localhost:3001/api/health')
+      const healthResponse = await fetch(backendUrl('/api/health'))
       const healthData = await healthResponse.json()
       console.log('Test 1 - Backend health:', healthData.status)
       
@@ -23,7 +24,7 @@ const DebugPanel: React.FC = () => {
       }
       
       // Test 2: Test calendar connection
-      const testResponse = await fetch('http://localhost:3001/api/calendar/test')
+      const testResponse = await fetch(backendUrl('/api/calendar/test'))
       console.log('Test 2 - Calendar test:', testResponse.status)
       
       if (testResponse.status === 401) {

--- a/src/components/DirectTest.tsx
+++ b/src/components/DirectTest.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { Zap, CheckCircle, XCircle, Loader, AlertTriangle, Shield, ExternalLink } from 'lucide-react'
+import { backendUrl } from '../utils/backend'
 
 const DirectTest: React.FC = () => {
   const [testResult, setTestResult] = useState<string | null>(null)
@@ -67,7 +68,7 @@ const DirectTest: React.FC = () => {
       addDiagnostic('Testing with backend proxy approach...')
       
       // Test 1: Check backend health
-      const healthResponse = await fetch('http://localhost:3001/api/health')
+      const healthResponse = await fetch(backendUrl('/api/health'))
       const healthData = await healthResponse.json()
       addDiagnostic(`Backend health: ${healthData.status}`)
       addDiagnostic(`OAuth2 configured: ${healthData.oauthConfigured}`)
@@ -78,7 +79,7 @@ const DirectTest: React.FC = () => {
       }
 
       // Test 2: Try to test calendar API
-      const testResponse = await fetch('http://localhost:3001/api/calendar/test')
+      const testResponse = await fetch(backendUrl('/api/calendar/test'))
       addDiagnostic(`Calendar test response: ${testResponse.status}`)
 
       if (testResponse.status === 401) {
@@ -116,7 +117,7 @@ const DirectTest: React.FC = () => {
       addDiagnostic('Testing OAuth2 authentication flow...')
       
       // Get auth URL from backend
-      const authResponse = await fetch('http://localhost:3001/auth/google')
+      const authResponse = await fetch(backendUrl('/auth/google'))
       const authData = await authResponse.json()
       
       if (authData.authUrl) {
@@ -143,7 +144,7 @@ const DirectTest: React.FC = () => {
     try {
       addDiagnostic('Starting OAuth2 authentication...')
       
-      const authResponse = await fetch('http://localhost:3001/auth/google')
+      const authResponse = await fetch(backendUrl('/auth/google'))
       const authData = await authResponse.json()
       
       if (authData.authUrl) {
@@ -170,7 +171,7 @@ const DirectTest: React.FC = () => {
     try {
       addDiagnostic('Checking authentication status...')
       
-      const testResponse = await fetch('http://localhost:3001/api/calendar/test')
+      const testResponse = await fetch(backendUrl('/api/calendar/test'))
       addDiagnostic(`Status check response: ${testResponse.status}`)
 
       if (testResponse.ok) {

--- a/src/components/HomeHub.tsx
+++ b/src/components/HomeHub.tsx
@@ -4,6 +4,7 @@ import { CalendarEvent } from '../types/calendar'
 import { useCalendar } from '../hooks/useCalendar'
 import { Clock, MapPin, Users, Mic, MicOff, Volume2, Calendar, ChevronLeft, ChevronRight } from 'lucide-react'
 import CalendarDisplay from './CalendarDisplay'
+import { backendUrl } from '../utils/backend'
 
 const HomeHub: React.FC = () => {
   const [currentDate, setCurrentDate] = useState(new Date())
@@ -153,7 +154,7 @@ const HomeHub: React.FC = () => {
       const formData = new FormData()
       formData.append('audio', audioBlob, 'recording.wav')
 
-      const response = await fetch('http://localhost:3001/api/whisper', {
+      const response = await fetch(backendUrl('/api/whisper'), {
         method: 'POST',
         body: formData
       })

--- a/src/components/SetupGuide.tsx
+++ b/src/components/SetupGuide.tsx
@@ -29,7 +29,10 @@ const SetupGuide: React.FC = () => {
               <li>Create a new project or select an existing one</li>
               <li>Enable the Google Calendar API</li>
               <li>Create OAuth2 credentials (not API key)</li>
-              <li>Add redirect URI: <code className="bg-dark-700 px-2 py-1 rounded">http://localhost:3001/auth/google/callback</code></li>
+              <li>
+                Add redirect URI:
+                <code className="bg-dark-700 px-2 py-1 rounded">http://&lt;YOUR_BACKEND_URL&gt;:3001/auth/google/callback</code>
+              </li>
             </ol>
           </div>
 
@@ -46,10 +49,13 @@ const SetupGuide: React.FC = () => {
             <div className="bg-dark-700 rounded-lg p-4 mb-4">
               <div className="flex items-center justify-between mb-2">
                 <span className="text-sm text-gray-400">Environment Variables</span>
-                <button 
-                  onClick={() => copyToClipboard(`VITE_GOOGLE_CLIENT_ID=your_oauth2_client_id_here
+                <button
+                  onClick={() =>
+                    copyToClipboard(`VITE_GOOGLE_CLIENT_ID=your_oauth2_client_id_here
 VITE_GOOGLE_CLIENT_SECRET=your_oauth2_client_secret_here
-VITE_GOOGLE_CALENDAR_ID=your_calendar_id_here`)}
+VITE_GOOGLE_CALENDAR_ID=your_calendar_id_here
+VITE_BACKEND_URL=http://<YOUR_BACKEND_URL>:3001`)
+                  }
                   className="text-primary-400 hover:text-primary-300 text-sm flex items-center"
                 >
                   <Copy className="w-4 h-4 mr-1" />
@@ -59,7 +65,8 @@ VITE_GOOGLE_CALENDAR_ID=your_calendar_id_here`)}
               <pre className="text-sm text-green-400 overflow-x-auto">
 {`VITE_GOOGLE_CLIENT_ID=your_oauth2_client_id_here
 VITE_GOOGLE_CLIENT_SECRET=your_oauth2_client_secret_here
-VITE_GOOGLE_CALENDAR_ID=your_calendar_id_here`}
+VITE_GOOGLE_CALENDAR_ID=your_calendar_id_here
+VITE_BACKEND_URL=http://<YOUR_BACKEND_URL>:3001`}
               </pre>
             </div>
           </div>
@@ -121,7 +128,7 @@ VITE_GOOGLE_CALENDAR_ID=your_calendar_id_here`}
               <li>• Make sure both frontend and backend servers are running</li>
               <li>• Verify OAuth2 credentials are correct in .env file</li>
               <li>• Check that you're added as a test user in OAuth consent screen</li>
-              <li>• Ensure redirect URI matches exactly: http://localhost:3001/auth/google/callback</li>
+              <li>• Ensure redirect URI matches exactly: http://&lt;YOUR_BACKEND_URL&gt;:3001/auth/google/callback</li>
               <li>• Try the authentication test at /auth route first</li>
             </ul>
           </div>

--- a/src/services/googleCalendar.ts
+++ b/src/services/googleCalendar.ts
@@ -1,6 +1,7 @@
 import { CalendarEvent, CalendarApiResponse } from '../types/calendar'
+import { backendUrl } from '../utils/backend'
 
-const BACKEND_API_BASE = 'http://localhost:3001/api'
+const BACKEND_API_BASE = backendUrl('/api')
 
 interface GoogleCalendarConfig {
   apiKey: string

--- a/src/utils/backend.ts
+++ b/src/utils/backend.ts
@@ -1,0 +1,19 @@
+// Utility helpers for constructing backend URLs
+
+/**
+ * Base URL for the backend API. When VITE_BACKEND_URL is not set,
+ * requests will be made relative to the current host.
+ */
+export const BACKEND_BASE_URL = import.meta.env.VITE_BACKEND_URL || ''
+
+/**
+ * Build a URL for the backend by optionally prefixing with BACKEND_BASE_URL.
+ * @param path Path beginning with '/'
+ * @returns Full URL string pointing to the backend
+ */
+export function backendUrl(path: string): string {
+  if (!path.startsWith('/')) {
+    path = `/${path}`
+  }
+  return BACKEND_BASE_URL ? `${BACKEND_BASE_URL}${path}` : path
+}

--- a/start-home-hub.sh
+++ b/start-home-hub.sh
@@ -101,8 +101,9 @@ BACKEND_PID=$!
 sleep 5
 
 # Check if backend is running
-if curl -s http://localhost:3001/api/health > /dev/null 2>&1; then
-    print_success "Backend server is running on http://localhost:3001"
+BACKEND_URL="${VITE_BACKEND_URL:-http://localhost:3001}"
+if curl -s "$BACKEND_URL/api/health" > /dev/null 2>&1; then
+    print_success "Backend server is running on $BACKEND_URL"
 else
     print_error "Backend server failed to start"
     print_status "Checking backend logs..."
@@ -140,9 +141,9 @@ echo "   Local:  http://localhost:5173/"
 echo "   Network: http://$IP_ADDRESS:5173/"
 echo ""
 echo "🔧 Backend URLs:"
-echo "   Health: http://localhost:3001/api/health"
-echo "   OAuth:  http://localhost:3001/auth/google"
-echo "   Calendar: http://localhost:3001/api/calendar/list"
+echo "   Health: $BACKEND_URL/api/health"
+echo "   OAuth:  $BACKEND_URL/auth/google"
+echo "   Calendar: $BACKEND_URL/api/calendar/list"
 echo ""
 echo "💡 To access from Windows browser:"
 echo "   http://$IP_ADDRESS:5173/"

--- a/update-env.ps1
+++ b/update-env.ps1
@@ -29,5 +29,5 @@ Write-Host "📝 Next steps:" -ForegroundColor Yellow
 Write-Host "1. Go to Google Cloud Console > APIs & Services > Credentials" -ForegroundColor White
 Write-Host "2. Find your OAuth2 client and copy the Client Secret" -ForegroundColor White
 Write-Host "3. Replace 'YOUR_CLIENT_SECRET_HERE' in the .env file" -ForegroundColor White
-Write-Host "4. Make sure the redirect URI is set to: http://localhost:3001/auth/google/callback" -ForegroundColor White
+Write-Host "4. Make sure the redirect URI is set to: http://<YOUR_BACKEND_URL>:3001/auth/google/callback" -ForegroundColor White
 Write-Host "5. Restart the backend server: npm run server" -ForegroundColor White 


### PR DESCRIPTION
## Summary
- add `VITE_BACKEND_URL` in example env
- centralize backend URL logic via `src/utils/backend.ts`
- update frontend components to use `backendUrl()`
- make server redirect URI configurable
- adjust setup docs and helper scripts for configurable backend URL
- tweak ESLint config to use the proper plugin prefix

## Testing
- `npm run lint` *(fails: 17 errors, 2 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6872b8f63220832dae087e110451c486